### PR TITLE
Updated standalone-ha.xml to fix 'socket-binding' error

### DIFF
--- a/torquebox/templates/default/standalone-ha-2.0.x-incremental.xml.erb
+++ b/torquebox/templates/default/standalone-ha-2.0.x-incremental.xml.erb
@@ -44,6 +44,7 @@
         <extension module='org.torquebox.web'/>
         <extension module='org.projectodd.polyglot.hasingleton'/>
         <extension module='org.projectodd.polyglot.cache'/>
+        <extension module='org.projectodd.polyglot.stomp'/>
     </extensions>
     <system-properties>
         <property name='org.apache.tomcat.util.http.ServerCookie.FWD_SLASH_IS_SEPARATOR' value='false'/>
@@ -579,10 +580,11 @@
         <subsystem xmlns='urn:jboss:domain:torquebox-messaging:1.0'/>
         <subsystem xmlns='urn:jboss:domain:torquebox-security:1.0'/>
         <subsystem xmlns='urn:jboss:domain:torquebox-services:1.0'/>
-        <subsystem xmlns='urn:jboss:domain:torquebox-stomp:1.0' socket-binding='stomp'/>
+        <subsystem xmlns='urn:jboss:domain:torquebox-stomp:1.0'/>
         <subsystem xmlns='urn:jboss:domain:torquebox-web:1.0'/>
         <subsystem xmlns='urn:jboss:domain:polyglot-hasingleton:1.0'/>
         <subsystem xmlns='urn:jboss:domain:polyglot-cache:1.0'/>
+        <subsystem xmlns='urn:jboss:domain:polyglot-stomp:1.0' socket-binding='stomp'/>
     </profile>
     <interfaces>
         <interface name='management'>


### PR DESCRIPTION
I was getting an error in boot.log something about 'socket-binding' (I lost the log). I diffed the ha xml from the latest build and this one. This change was the first thing I tried, and it fixed the problem.

I don't know enough about the settings to know for sure what I did. I also don't know how many people are using chef to deploy, but it would be nice if breaking changes could get folded into this repo.

Thanks!
