### PR TITLE
Install jruby-openssl using Torquebox JRuby installation

### DIFF
--- a/torquebox/providers/application.rb
+++ b/torquebox/providers/application.rb
@@ -6,13 +6,15 @@ def initialize(*args)
 end
 
 action :deploy do
-  execute "torquebox deploy #{new_resource.path}" do
+  execute "torquebox deploy" do
+    command "torquebox deploy #{new_resource.path} --name=#{new_resource.name} --env=#{new_resource.env}"
     creates "#{deployments}/#{new_resource.name}-knob.yml.deployed"
   end
 end
 
 action :undeploy do
-  execute "torquebox undeploy #{new_resource.path}" do
+  execute "torquebox undeploy" do
+    command "torquebox undeploy #{new_resource.path} --name=#{new_resource.name}"
     creates "#{deployments}/#{new_resource.name}-knob.yml.undeployed"
   end
 end

--- a/torquebox/recipes/server.rb
+++ b/torquebox/recipes/server.rb
@@ -82,8 +82,10 @@ end
 announce(:torquebox, :server)
 
 # otherwise bundler won't work in jruby
-gem_package 'jruby-openssl' do
-  gem_binary "#{current}/jruby/bin/jgem"
+execute "install jruby-openssl" do
+  command "#{current}/jruby/bin/jgem install jruby-openssl -q --no-document"
+  user "torquebox"
+  returns [0, '0', '', nil]
 end
 
 #allows use of 'torquebox' command through sudo

--- a/torquebox/recipes/server.rb
+++ b/torquebox/recipes/server.rb
@@ -86,6 +86,7 @@ execute "install jruby-openssl" do
   command "#{current}/jruby/bin/jgem install jruby-openssl -q --no-document"
   user "torquebox"
   returns [0, '0', '', nil]
+  not_if "#{current}/jruby/bin/jgem list jruby-openssl -i"
 end
 
 #allows use of 'torquebox' command through sudo

--- a/torquebox/resources/application.rb
+++ b/torquebox/resources/application.rb
@@ -1,3 +1,4 @@
 actions :deploy, :undeploy
 
 attribute :path, :kind_of => String, :required => true
+attribute :environment, :kind_of => String, :default => 'development'

--- a/torquebox/resources/application.rb
+++ b/torquebox/resources/application.rb
@@ -1,4 +1,4 @@
 actions :deploy, :undeploy
 
 attribute :path, :kind_of => String, :required => true
-attribute :environment, :kind_of => String, :default => 'development'
+attribute :env, :kind_of => String, :default => 'development'


### PR DESCRIPTION
Using the `gem_package` resource was causing chef to try and install `jruby-openssl` using it's built in version of gem, instead of the Torquebox provided gem binary. This workaround isn't perfect, but it seems to work quite well.
